### PR TITLE
feat: allow url inputs for posts and comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Application code lives in `src/`, grouped by Band API feature folders (e.g., `posts/`, `writeComment/`) that surface `ToolDefinition` exports to `src/tools.ts`. Shared helpers reside in `src/pagination`, `src/config.ts`, and `src/types/`, while Jest specs sit in `src/__tests__/` and release automation in `specs/`. Build output lands in `dist/`, and the CLI wrapper `bin/band-mcp-server` boots the compiled server; keep feature-specific fixtures next to the handler they exercise.
+
+## Build, Test, and Development Commands
+- `npm run build` / `make build` — compile TypeScript with `tsc` into `dist/`.
+- `npm run dev` (`make dev`) — watch `src/index.ts` with `tsx` for local iteration.
+- `npm test` — run the Jest suite; `npm run test:watch` keeps it hot while developing.
+- `npm run lint` / `npm run lint:fix` — enforce ESLint rules before review.
+- `make docker-build` / `make docker-run` — produce and validate the production image with `BAND_ACCESS_TOKEN` injected.
+
+## Coding Style & Naming Conventions
+Code is strict TypeScript targeting ES2022 modules; rely on two-space indentation and keep exports named to mirror the Band capability (e.g., `removePost.handleToolCall`). DTOs and schema types belong in `types/`, and shared pagination utilities stay centralized to avoid drift. Run the linter prior to commits and keep `zod` validations adjacent to their handlers so errors remain localized.
+
+## Testing Guidelines
+Jest with `ts-jest` powers the unit tests; keep files in `src/__tests__/` using the `<feature>.<behavior>.test.ts` pattern such as `pagination.adapter.test.ts`. Mock axios calls to avoid live Band traffic and cover success, validation, and error paths whenever introducing or changing a tool handler. Execute `npm test` (or `npm run test:watch`) before pushing and add regression cases when triaging bugs.
+
+## Commit & Pull Request Guidelines
+Recent history favors `<type>: summary (#issue)` subjects (`feat: pagination adapter + ...`), optionally mixing languages; stick to imperative mood and keep commits scoped. PRs should describe the Band surface area touched, list manual verification steps (CLI, Docker, or tests), and link the relevant issue. Include screenshots only when the change affects human-facing output or logs.
+
+## Security & Configuration Tips
+Never commit secrets or `.env` files; set `BAND_ACCESS_TOKEN` via the shell when running `npm run dev` or Docker targets. Trim sensitive payloads from logs and confirm any new configuration defaults are documented in `README.md` before release.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ This MCP server is fully implemented and provides complete access to Band API fu
 }
 ```
 
+### Tool Tips
+
+- `get_posts` now accepts either a raw `band_key` or a full Band URL such as `https://band.us/band/{band_key}`. When a URL is supplied the server extracts the `band_key` automatically.
+- `get_comments` likewise accepts a comment or post URL (e.g. `https://band.us/band/{band_key}/post/{post_key}?commentId={comment_key}`) and filters the response down to the referenced comment when possible.
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,9 @@ export default {
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.d.ts',

--- a/src/__tests__/band.url.test.ts
+++ b/src/__tests__/band.url.test.ts
@@ -1,0 +1,36 @@
+import { BandUrlParseError, parseBandUrl } from "../url.js";
+
+describe("parseBandUrl", () => {
+  it("extracts band key from band page url", () => {
+    const result = parseBandUrl("https://band.us/band/AzIEz54gxWeSAB_nwygZ95");
+    expect(result).toEqual({ bandKey: "AzIEz54gxWeSAB_nwygZ95" });
+  });
+
+  it("extracts post and comment identifiers", () => {
+    const result = parseBandUrl(
+      "https://band.us/band/AAAbBbMeQHBLh3-y8xxogqBg/post/AAAFJEEalAmkhLXGh0rQCy3h?commentId=AADGZXHAFeWdd1NaGsc5hN07",
+    );
+
+    expect(result).toEqual({
+      bandKey: "AAAbBbMeQHBLh3-y8xxogqBg",
+      postKey: "AAAFJEEalAmkhLXGh0rQCy3h",
+      commentKey: "AADGZXHAFeWdd1NaGsc5hN07",
+    });
+  });
+
+  it("supports alternate comment query parameters", () => {
+    const result = parseBandUrl(
+      "https://band.us/band/key/post/post?comment_key=COMMENT123",
+    );
+
+    expect(result.commentKey).toBe("COMMENT123");
+  });
+
+  it("throws for non band domains", () => {
+    expect(() => parseBandUrl("https://example.com/band/abc")).toThrow(BandUrlParseError);
+  });
+
+  it("throws when band key is missing", () => {
+    expect(() => parseBandUrl("https://band.us/")).toThrow(BandUrlParseError);
+  });
+});

--- a/src/__tests__/comments.tool.test.ts
+++ b/src/__tests__/comments.tool.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
+
+let handleToolCall: typeof import("../comments/tool.js")["handleToolCall"];
+let bandApiClient: typeof import("../client.js")["bandApiClient"];
+
+beforeAll(async () => {
+  ({ handleToolCall } = await import("../comments/tool.js"));
+  ({ bandApiClient } = await import("../client.js"));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("comments tool handleToolCall", () => {
+  it("derives identifiers from url and filters the target comment", async () => {
+    const getMock = jest
+      .spyOn(bandApiClient, "get")
+      .mockResolvedValue({
+        paging: { previous_params: null, next_params: null },
+        items: [
+          {
+            comment_key: "AAA",
+            content: "first",
+            created_at: 0,
+            author: { name: "a", description: "", profile_image_url: "" },
+          },
+          {
+            comment_key: "TARGET",
+            content: "target",
+            created_at: 0,
+            author: { name: "b", description: "", profile_image_url: "" },
+          },
+        ],
+      } as never);
+
+    const response = await handleToolCall(
+      undefined,
+      undefined,
+      undefined,
+      "https://band.us/band/BAND_KEY/post/POST_KEY?commentId=TARGET"
+    );
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/v2/band/post/comments",
+      { band_key: "BAND_KEY", post_key: "POST_KEY" }
+    );
+
+    const payload = JSON.parse(response.content[0].text) as {
+      items: Array<{ comment_key: string }>;
+    };
+    expect(payload.items).toHaveLength(1);
+    expect(payload.items[0].comment_key).toBe("TARGET");
+  });
+
+  it("throws when requested comment is not found", async () => {
+    jest
+      .spyOn(bandApiClient, "get")
+      .mockResolvedValue({
+        paging: { previous_params: null, next_params: null },
+        items: [],
+      } as never);
+
+    await expect(
+      handleToolCall(
+        undefined,
+        undefined,
+        undefined,
+        "https://band.us/band/BAND/post/POST?commentId=MISSING"
+      )
+    ).rejects.toThrow(
+      "Comment MISSING was not found in the retrieved page. Try fetching the comments without filtering or adjust pagination."
+    );
+  });
+
+  it("throws when neither identifiers nor url provided", async () => {
+    await expect(
+      handleToolCall(undefined, undefined)
+    ).rejects.toThrow(
+      "band_key and post_key are required unless a valid BAND url is provided."
+    );
+  });
+});

--- a/src/__tests__/posts.tool.test.ts
+++ b/src/__tests__/posts.tool.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
+
+let handleToolCall: typeof import("../posts/tool.js")["handleToolCall"];
+let bandApiClient: typeof import("../client.js")["bandApiClient"];
+
+beforeAll(async () => {
+  ({ handleToolCall } = await import("../posts/tool.js"));
+  ({ bandApiClient } = await import("../client.js"));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("posts tool handleToolCall", () => {
+  it("derives band key from url when band_key missing", async () => {
+    const getMock = jest
+      .spyOn(bandApiClient, "get")
+      .mockResolvedValue({
+        paging: { previous_params: null, next_params: null },
+        items: [],
+      } as never);
+
+    await handleToolCall(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "https://band.us/band/AAAbBbMeQHBLh3-y8xxogqBg"
+    );
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/v2/band/posts",
+      { band_key: "AAAbBbMeQHBLh3-y8xxogqBg", locale: "ja_JP" }
+    );
+  });
+
+  it("respects user provided locale and trims identifiers", async () => {
+    const getMock = jest
+      .spyOn(bandApiClient, "get")
+      .mockResolvedValue({
+        paging: { previous_params: null, next_params: null },
+        items: [],
+      } as never);
+
+    await handleToolCall(
+      "  SOME_KEY  ",
+      "en_US",
+      undefined,
+      50,
+      undefined
+    );
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/v2/band/posts",
+      { band_key: "SOME_KEY", locale: "en_US", limit: 50 }
+    );
+  });
+
+  it("throws when neither band_key nor url provided", async () => {
+    await expect(
+      handleToolCall(undefined, undefined)
+    ).rejects.toThrow("Either band_key or a valid BAND url must be provided.");
+  });
+});

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -37,18 +37,20 @@ export function handleToolCall(name: string, args: unknown) {
         return bands.handleToolCall();
       case "get_posts":
         return posts.handleToolCall(
-          a.band_key as string,
-          a.locale as string,
+          a.band_key as string | undefined,
+          a.locale as string | undefined,
           a.after as string | undefined,
-          a.limit as number | undefined
+          a.limit as number | undefined,
+          a.url as string | undefined
         );
       case "get_post":
         return post.handleToolCall(a.band_key as string, a.post_key as string);
       case "get_comments":
         return comments.handleToolCall(
-          a.band_key as string,
-          a.post_key as string,
-          a.sort as string | undefined
+          a.band_key as string | undefined,
+          a.post_key as string | undefined,
+          a.sort as string | undefined,
+          a.url as string | undefined
         );
       case "permissions":
         return permissions.handleToolCall(

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,0 +1,70 @@
+const COMMENT_PARAM_KEYS = ["commentId", "comment_id", "commentKey", "comment_key"] as const;
+
+export interface ParsedBandUrl {
+  bandKey: string;
+  postKey?: string;
+  commentKey?: string;
+}
+
+export class BandUrlParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BandUrlParseError";
+  }
+}
+
+function normalize(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function parseBandUrl(rawUrl: string): ParsedBandUrl {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch (error) {
+    throw new BandUrlParseError(`Invalid URL: ${(error as Error).message}`);
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (!hostname.endsWith("band.us")) {
+    throw new BandUrlParseError("URL must belong to band.us");
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments.length < 2 || segments[0] !== "band") {
+    throw new BandUrlParseError("Unsupported BAND URL format: missing band key");
+  }
+
+  const bandKey = segments[1];
+  if (!bandKey) {
+    throw new BandUrlParseError("Band key was not found in the URL");
+  }
+
+  let postKey: string | undefined;
+  if (segments.length >= 4 && segments[2] === "post") {
+    postKey = segments[3];
+  }
+
+  let commentKey: string | undefined;
+  for (const key of COMMENT_PARAM_KEYS) {
+    const candidate = normalize(url.searchParams.get(key));
+    if (candidate) {
+      commentKey = candidate;
+      break;
+    }
+  }
+
+  const result: ParsedBandUrl = { bandKey };
+
+  if (postKey) {
+    result.postKey = postKey;
+  }
+
+  if (commentKey) {
+    result.commentKey = commentKey;
+  }
+
+  return result;
+}


### PR DESCRIPTION
  ## Summary
  - allow `get_posts` to accept either a `band_key` or a pasted BAND URL and resolve identifiers
  automatically
  - let `get_comments` parse comment/post URLs, filter by the requested comment, and surface clear errors
  when it cannot
  - add a shared URL parser, unit tests for parsing and tool behaviour, and README guidance for the new
  workflow

  ## Testing
  - npm run build
  - npm test