### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A fully functional [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that integrates with the [Band API](https://developers.band.us/develop/guide/api). This server enables seamless interaction with the Band social platform through AI assistants and other MCP-compatible tools.
 
+<a href="https://glama.ai/mcp/servers/@kanghouchao/band-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kanghouchao/band-mcp-server/badge" alt="Band Server MCP server" />
+</a>
+
 ## Overview
 
 This server can be used in two primary ways:


### PR DESCRIPTION
This PR adds a badge for the [Band MCP Server](https://glama.ai/mcp/servers/@kanghouchao/band-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kanghouchao/band-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kanghouchao/band-mcp-server/badge" alt="Band Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.